### PR TITLE
Implements #22 - Update PHP, Symfony and dependencies

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm-alpine
+FROM php:8.5-fpm-alpine
 
 ARG UID
 ARG GID
@@ -13,8 +13,7 @@ RUN apk update && apk add \
     bash \
     icu-dev \
     && docker-php-ext-configure intl \
-    && docker-php-ext-install intl opcache \
-    && docker-php-ext-enable opcache
+    && docker-php-ext-install intl
 
 RUN ln -s /usr/share/zoneinfo/Europe/Paris /etc/localtime \
     && sed -i "s/^;date.timezone =.*/date.timezone = Europe\/Paris/" $PHP_INI_DIR/php.ini

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer:v2
       - name: Install Composer dependencies (locked)
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer:v2
       - name: Install Composer dependencies (locked)
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer:v2
       - name: Install Composer dependencies (locked)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,12 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
         dependencies: [highest]
         allowed-to-fail: [false]
         symfony-require: ['']
         variant: [normal]
         include:
-          - php-version: '8.1'
-            dependencies: highest
-            allowed-to-fail: false
-            symfony-require: 6.4.*
-            variant: symfony/symfony:"6.4.*"
           - php-version: '8.2'
             dependencies: highest
             allowed-to-fail: false
@@ -41,8 +37,8 @@ jobs:
           - php-version: '8.2'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
           - php-version: '8.3'
             dependencies: highest
             allowed-to-fail: false
@@ -51,8 +47,8 @@ jobs:
           - php-version: '8.3'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
           - php-version: '8.4'
             dependencies: highest
             allowed-to-fail: false
@@ -61,12 +57,31 @@ jobs:
           - php-version: '8.4'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
-
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
+          - php-version: '8.4'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 8.*
+            variant: symfony/symfony:"8.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 6.4.*
+            variant: symfony/symfony:"6.4.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 8.*
+            variant: symfony/symfony:"8.*"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,8 +24,8 @@ $fileHeaderComment = <<<'EOF'
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PHP82Migration' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP8x2Migration' => true,
+        '@PHPUnit7x5Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'protected_to_private' => false,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,7 +24,6 @@ $fileHeaderComment = <<<'EOF'
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PHP71Migration' => true,
         '@PHP82Migration' => true,
         '@PHPUnit75Migration:risky' => true,
         '@Symfony' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v3.0
+------
+
+### Changes
+* [#22](https://github.com/cleverage/rest-process-bundle/issues/22) Add support for PHP 8.5 and Symfony 8.* Update phpunit/phpunit to version >10.0 Bump version to cleverage/process-bundle ^5.0
+
+### BC breaks
+* [#22](https://github.com/cleverage/rest-process-bundle/issues/22) Remove support for PHP 8.1 and Symfony 7.3
+
 v2.3
 ------
 

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "require": {
         "php": ">=8.2",
         "cleverage/process-bundle": "^5.0",
-        "symfony/http-client": "^6.4|^7.4|^8"
+        "symfony/http-client": "^6.4 || ^7.4 || ^8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "*",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,12 @@
             "email": "mveyrenc@clever-age.com",
             "homepage": "https://github.com/mveyrenc",
             "role": "Developer"
+        },
+        {
+          "name": "Xavier Marchegay",
+          "email": "xmarchegay@clever-age.com",
+          "homepage": "https://github.com/xmarchegay",
+          "role": "Lead Developer"
         }
     ],
     "autoload": {
@@ -43,16 +49,16 @@
         }
     },
     "require": {
-        "php": ">=8.1",
-        "cleverage/process-bundle": "^4.0",
-        "symfony/http-client": "^6.4|^7.3"
+        "php": ">=8.2",
+        "cleverage/process-bundle": "^5.0",
+        "symfony/http-client": "^6.4|^7.4|^8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "*",
         "phpstan/extension-installer": "*",
         "phpstan/phpstan": "*",
         "phpstan/phpstan-symfony": "*",
-        "phpunit/phpunit": "<10.0",
+        "phpunit/phpunit": "*",
         "rector/rector": "*",
         "roave/security-advisories": "dev-latest",
         "symfony/test-pack": "^1.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
+         cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
          failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
+         failOnWarning="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -8,17 +8,17 @@ use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
-    ->withPhpVersion(PhpVersion::PHP_84)
+    ->withPhpVersion(PhpVersion::PHP_85)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/tests',
     ])
-    ->withPhpSets(php81: true)
+    ->withPhpSets(php82: true)
     // here we can define, what prepared sets of rules will be applied
     ->withPreparedSets(deadCode: true, codeQuality: true, symfonyCodeQuality: true)
     ->withAttributesSets(symfony: true)
     ->withSets([
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
         SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
@@ -19,6 +20,7 @@ return RectorConfig::configure()
     ->withAttributesSets(symfony: true)
     ->withSets([
         LevelSetList::UP_TO_PHP_82,
+        PHPUnitSetList::PHPUNIT_100,
         SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,


### PR DESCRIPTION
## Description

* Bump PHP to 8.2+ and enable support for Symfony 6.4, 7.4, and 8.0 in composer.json.
* Add PHP 8.5 support in GitHub workflows and Docker configuration.
* Update PHPUnit dependencies
* Migrate from PHPDoc annotations to PHPUnit attributes in test classes.
* Update .github/workflows/test.yml and .github/workflows/quality.yml to use actions/checkout@v6.
* Adjust Rector configuration for PHP 8.5 compatibility.
* Update Dockerfile to reflect changes in PHP version and simplifications.
* Update CHANGELOG.md

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes

* Drop support for PHP 8.1 and Symfony 7.3
